### PR TITLE
Add missing Eloquent Sluggable package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "require": {
         "php": ">=5.5.9",
         "packagebackup/laravel-service-provider": "1.0.*@dev",
+        "cviebrock/eloquent-sluggable": "3.1.*",
         "illuminate/database": "~5.0|~5.1",
         "nesbot/carbon": ">=1.20.0"
     },


### PR DESCRIPTION
Before installing this package, I got this error when publishing the migrations:

    [Symfony\Component\Debug\Exception\FatalErrorException]
    Class 'Cviebrock\EloquentSluggable\SluggableServiceProvider' not found

Adding `eloquent-sluggable` to my `composer.json` fixed the issue.